### PR TITLE
feat: support reading QR codes from ImageData

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ quirc.decode(img).then((codes) => {
 }).catch((err) => {
     // handle err.
 });
+
+// alternatively, use an already-loaded ImageData, e.g. from a Canvas element
+const context = canvas.getContext('2d');
+const imageData = context.getImageData(0, 0, 800, 600);
+quirc.decode(imageData).then((codes) => {
+    // do something with codes.
+}).catch((err) => {
+    // handle err.
+});
 ```
 
 output:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ and a `constants` object.
 
 
 ## decode(img[, callback])
-`img` must be a `Buffer` of a PNG or JPEG encoded image file.
+`img` must be either a `Buffer` of a PNG or JPEG encoded image file, or a
+decoded image in [`ImageData`](https://developer.mozilla.org/en-US/docs/Web/API/ImageData)
+format with 1 (grayscale), 3 (RGB) or 4 (RGBA) channels.
 
 When `callback` is provided, it is expected to be a "classic" Node.js callback
 function, taking an error as first argument and the result as second argument.
@@ -51,11 +53,16 @@ quirc.decode(img).then((codes) => {
     // handle err.
 });
 
-// alternatively, use an already-loaded ImageData, e.g. from a Canvas element
+// alternatively, use an already-loaded ImageData, e.g. from the `canvas` library
 const context = canvas.getContext('2d');
 const imageData = context.getImageData(0, 0, 800, 600);
 quirc.decode(imageData).then((codes) => {
     // do something with codes.
+    console.log(`codes read from ImageData (size=${
+        imageData.data.length
+    }, width=${imageData.width}, height=${
+        imageData.height
+    }):`, codes);
 }).catch((err) => {
     // handle err.
 });

--- a/index.js
+++ b/index.js
@@ -3,48 +3,68 @@
 // Our C++ Addon
 const addon = require('bindings')('node-quirc.node');
 
+function decodeEncoded(img, callback) {
+    return addon.decodeEncoded(img, callback);
+}
+
+function isImageDimension(number) {
+    return (
+        typeof number === 'number' &&
+        number > 0 &&
+        (number | 0) === number &&
+        !isNaN(number)
+    );
+}
+
+function decodeRaw(img, callback) {
+    if (!isImageDimension(img.width)) {
+        throw new Error(
+            `unexpected width value for image: ${img.width}`
+        )
+    }
+    if (!isImageDimension(img.height)) {
+        throw new Error(
+            `unexpected height value for image: ${img.height}`
+        )
+    }
+    const channels = img.data.length / img.width / img.height;
+    if (channels !== 1 && channels !== 3 && channels !== 4) {
+        throw new Error(
+            `unsupported ${channels}-channel image, expected 1, 3, or 4`
+        );
+    }
+    return addon.decodeRaw(img.data, img.width, img.height, callback);
+}
+
+function maybePromisify(fn) {
+    return (...args) => {
+        if (args.length < fn.length) {
+            return new Promise((resolve, reject) => {
+                fn(...args, (err, results) => {
+                    if (err) {
+                        return reject(err);
+                    } else {
+                        return resolve(results);
+                    }
+                });
+            });
+        } else {
+            return fn(...args);
+        }
+    };
+}
+
 // public API
 module.exports = {
-    decode(img, callback) {
+    decode: maybePromisify((img, callback) => {
         if (Buffer.isBuffer(img)) {
-            if (callback) {
-                return addon.decodeEncoded(img, callback);
-            } else {
-                return new Promise((resolve, reject) => {
-                    addon.decodeEncoded(img, (err, results) => {
-                        if (err) {
-                            return reject(err);
-                        } else {
-                            return resolve(results);
-                        }
-                    });
-                });
-            }
+            return decodeEncoded(img, callback);
         } else if (img && typeof img === "object") {
-            const channels = img.data.length / img.width / img.height;
-            if (channels !== 1 && channels !== 3 && channels !== 4) {
-                throw new Error(
-                    `unsupported ${channels}-channel image, expected 1, 3, or 4`
-                );
-            }
-
-            if (callback) {
-                addon.decodeRaw(img.data, img.width, img.height, callback);
-            } else {
-                return new Promise((resolve, reject) => {
-                    addon.decodeRaw(img.data, img.width, img.height, (err, results) => {
-                        if (err) {
-                            return reject(err);
-                        } else {
-                            return resolve(results);
-                        }
-                    });
-                });
-            }
+            return decodeRaw(img, callback);
         } else {
             throw new TypeError("img must be a Buffer or ImageData");
         }
-    },
+    }),
     constants: {
         // QR-code versions.
         VERSION_MIN:  1,

--- a/package-lock.json
+++ b/package-lock.json
@@ -600,6 +600,12 @@
         "iterate-iterator": "^1.0.1"
       }
     },
+    "jpeg-js": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.0.tgz",
+      "integrity": "sha512-960VHmtN1vTpasX/1LupLohdP5odwAT7oK/VSm6mW0M58LbrBnowLAPWAZhWGhDAGjzbMnPXZxzB/QYgBwkN0w==",
+      "dev": true
+    },
     "js-yaml": {
       "version": "3.14.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "chai": "^4.2.0",
+    "jpeg-js": "^0.4.0",
     "mocha": "^8.1.3"
   },
   "contributors": [

--- a/src/node-quirc.cc
+++ b/src/node-quirc.cc
@@ -26,12 +26,12 @@ class NodeQuircDecoder: public AsyncWorker
 	public:
 
 	/* ctor */
-	NodeQuircDecoder(Callback *callback, const uint8_t *img, size_t img_len, size_t width, size_t height):
+	NodeQuircDecoder(Callback *callback, const uint8_t *img, size_t img_len, size_t img_width, size_t img_height):
 	    AsyncWorker(callback),
 	    m_img(img),
 	    m_img_len(img_len),
-	    m_width(width),
-	    m_height(height),
+	    m_img_width(img_width),
+	    m_img_height(img_height),
 	    m_code_list(NULL)
 	{ }
 
@@ -48,7 +48,7 @@ class NodeQuircDecoder: public AsyncWorker
 	// everything we need for input and output should go on `this`.
 	void Execute()
 	{
-		m_code_list = nq_decode(m_img, m_img_len, m_width, m_height);
+		m_code_list = nq_decode(m_img, m_img_len, m_img_width, m_img_height);
 	}
 
 
@@ -89,8 +89,8 @@ class NodeQuircDecoder: public AsyncWorker
 	/* nq_decode() arguments */
 	const uint8_t	*m_img;
 	size_t		 m_img_len;
-	size_t		 m_width;
-	size_t		 m_height;
+	size_t		 m_img_width;
+	size_t		 m_img_height;
 	/* nq_decode() return value */
 	struct nq_code_list	*m_code_list;
 
@@ -154,6 +154,7 @@ NAN_METHOD(NodeQuircDecodeEncodedAsync) {
 NAN_METHOD(NodeQuircDecodeRawAsync) {
 	if (info.Length() < 4)
 		return ThrowError("expected (pixels, width, height, callback) as arguments");
+	// Uint8ClampedArray is from ImageData#data, Buffer is allowed for convenience.
 	if (!info[0]->IsUint8ClampedArray() && !node::Buffer::HasInstance(info[0]))
 		return ThrowTypeError("pixels must be a Uint8ClampedArray or Buffer");
 	if (!info[1]->IsNumber())
@@ -175,10 +176,10 @@ NAN_METHOD(NodeQuircDecodeRawAsync) {
 		img_len = data.length();
 	}
 
-	size_t width = (size_t)Nan::To<int>(info[1]).FromJust();
-	size_t height = (size_t)Nan::To<int>(info[2]).FromJust();
+	size_t img_width = (size_t)Nan::To<int>(info[1]).FromJust();
+	size_t img_height = (size_t)Nan::To<int>(info[2]).FromJust();
 	Callback *callback = new Callback(info[3].As<v8::Function>());
-	AsyncQueueWorker(new NodeQuircDecoder(callback, img, img_len, width, height));
+	AsyncQueueWorker(new NodeQuircDecoder(callback, img, img_len, img_width, img_height));
 }
 
 // export stuff to NodeJS

--- a/src/node-quirc.cc
+++ b/src/node-quirc.cc
@@ -26,10 +26,12 @@ class NodeQuircDecoder: public AsyncWorker
 	public:
 
 	/* ctor */
-	NodeQuircDecoder(Callback *callback, const uint8_t *img, size_t img_len):
+	NodeQuircDecoder(Callback *callback, const uint8_t *img, size_t img_len, size_t width, size_t height):
 	    AsyncWorker(callback),
 	    m_img(img),
 	    m_img_len(img_len),
+	    m_width(width),
+	    m_height(height),
 	    m_code_list(NULL)
 	{ }
 
@@ -46,7 +48,7 @@ class NodeQuircDecoder: public AsyncWorker
 	// everything we need for input and output should go on `this`.
 	void Execute()
 	{
-		m_code_list = nq_decode(m_img, m_img_len);
+		m_code_list = nq_decode(m_img, m_img_len, m_width, m_height);
 	}
 
 
@@ -87,6 +89,8 @@ class NodeQuircDecoder: public AsyncWorker
 	/* nq_decode() arguments */
 	const uint8_t	*m_img;
 	size_t		 m_img_len;
+	size_t		 m_width;
+	size_t		 m_height;
 	/* nq_decode() return value */
 	struct nq_code_list	*m_code_list;
 
@@ -133,7 +137,7 @@ class NodeQuircDecoder: public AsyncWorker
 
 
 // async access to nq_decode()
-NAN_METHOD(NodeQuircDecodeAsync) {
+NAN_METHOD(NodeQuircDecodeEncodedAsync) {
 	if (info.Length() < 2)
 		return ThrowError("expected (img, callback) as arguments");
 	if (!node::Buffer::HasInstance(info[0]))
@@ -144,14 +148,45 @@ NAN_METHOD(NodeQuircDecodeAsync) {
 	uint8_t *img   = (uint8_t *)node::Buffer::Data(info[0]);
 	size_t img_len = node::Buffer::Length(info[0]);
 	Callback *callback = new Callback(info[1].As<v8::Function>());
-	AsyncQueueWorker(new NodeQuircDecoder(callback, img, img_len));
+	AsyncQueueWorker(new NodeQuircDecoder(callback, img, img_len, 0, 0));
 }
 
+NAN_METHOD(NodeQuircDecodeRawAsync) {
+	if (info.Length() < 4)
+		return ThrowError("expected (pixels, width, height, callback) as arguments");
+	if (!info[0]->IsUint8ClampedArray() && !node::Buffer::HasInstance(info[0]))
+		return ThrowTypeError("pixels must be a Uint8ClampedArray or Buffer");
+	if (!info[1]->IsNumber())
+		return ThrowTypeError("width must be a number");
+	if (!info[2]->IsNumber())
+		return ThrowTypeError("height must be a number");
+	if (!info[3]->IsFunction())
+		return ThrowTypeError("callback must be a function");
+
+	uint8_t *img;
+	size_t img_len;
+
+	if (node::Buffer::HasInstance(info[0])) {
+		img = (uint8_t *)node::Buffer::Data(info[0]);
+		img_len = node::Buffer::Length(info[0]);
+	} else {
+		Nan::TypedArrayContents<uint8_t> data(info[0]);
+		img = *data;
+		img_len = data.length();
+	}
+
+	size_t width = (size_t)Nan::To<int>(info[1]).FromJust();
+	size_t height = (size_t)Nan::To<int>(info[2]).FromJust();
+	Callback *callback = new Callback(info[3].As<v8::Function>());
+	AsyncQueueWorker(new NodeQuircDecoder(callback, img, img_len, width, height));
+}
 
 // export stuff to NodeJS
 NAN_MODULE_INIT(NodeQuircInit) {
-	Set(target, New("decode").ToLocalChecked(),
-	    GetFunction(New<v8::FunctionTemplate>(NodeQuircDecodeAsync)).ToLocalChecked());
+	Set(target, New("decodeEncoded").ToLocalChecked(),
+	    GetFunction(New<v8::FunctionTemplate>(NodeQuircDecodeEncodedAsync)).ToLocalChecked());
+	Set(target, New("decodeRaw").ToLocalChecked(),
+	    GetFunction(New<v8::FunctionTemplate>(NodeQuircDecodeRawAsync)).ToLocalChecked());
 }
 
 

--- a/src/node_quirc_decode.h
+++ b/src/node_quirc_decode.h
@@ -10,7 +10,7 @@
 struct nq_code_list;
 struct nq_code;
 
-struct nq_code_list	*nq_decode(const uint8_t *img, size_t imglen);
+struct nq_code_list	*nq_decode(const uint8_t *img, size_t img_len, size_t width, size_t height);
 const char		*nq_code_list_err(const struct nq_code_list *list);
 unsigned int		 nq_code_list_size(const struct nq_code_list *list);
 const struct nq_code	*nq_code_at(const struct nq_code_list *list, unsigned int index);

--- a/test/index.js
+++ b/test/index.js
@@ -3,6 +3,7 @@
 const fs   = require("fs");
 const path = require("path");
 const util = require("util");
+const jpeg = require("jpeg-js");
 
 const chai   = require("chai");
 const expect = chai.expect;
@@ -355,6 +356,32 @@ describe("decode()", function () {
                 }
             }
         }
+    });
+
+    context("raw image data", function () {
+        it("should read QR codes from raw image data", function (done) {
+            const big_image_with_two_qrcodes = jpeg.decode(
+                read_test_data("big_image_with_two_qrcodes.jpeg")
+            );
+            quirc.decode(big_image_with_two_qrcodes, function (err, codes) {
+                expect(codes).to.be.an("array").and.to.have.length(2);
+                expect(codes[0].err).to.not.exist;
+                expect(codes[0].version).to.eql(4);
+                expect(codes[0].ecc_level).to.eql("M");
+                expect(codes[0].mask).to.eql(2);
+                expect(codes[0].mode).to.eql("BYTE");
+                expect(codes[0].data).to.be.an.instanceof(Buffer);
+                expect(codes[0].data.toString()).to.eql("from javascript");
+                expect(codes[1].err).to.not.exist;
+                expect(codes[1].version).to.eql(4);
+                expect(codes[1].ecc_level).to.eql("M");
+                expect(codes[1].mask).to.eql(2);
+                expect(codes[1].mode).to.eql("BYTE");
+                expect(codes[1].data).to.be.an.instanceof(Buffer);
+                expect(codes[1].data.toString()).to.eql("here comes qr!");
+                done();
+            });
+        });
     });
 
     context("regressions", function () {

--- a/test/index.js
+++ b/test/index.js
@@ -93,10 +93,13 @@ describe("constants", function () {
 
 describe("decode()", function () {
     describe("arguments", function () {
-        it("should throw an Error when no arguments are given", function () {
-            expect(function () {
-                quirc.decode();
-            }).to.throw(Error, "img must be a Buffer");
+        it("should return a rejected Promise when no arguments are given", function (done) {
+            const p = quirc.decode()
+            expect(p).to.be.a("Promise");
+            p.catch((e) => {
+                expect(e.message).to.eql("img must be a Buffer or ImageData");
+                done();
+            });
         });
         it("should return a Promise when only one argument is given", function () {
             const p = quirc.decode(Buffer.from("data"));
@@ -106,7 +109,7 @@ describe("decode()", function () {
         it("should throw when img is not a Buffer", function () {
             expect(function () {
                 quirc.decode("a string", function dummy() { });
-            }).to.throw(TypeError, "img must be a Buffer");
+            }).to.throw(TypeError, "img must be a Buffer or ImageData");
         });
         it("should throw when callback is not a function", function () {
             expect(function () {


### PR DESCRIPTION
Rather than requiring that the data be in PNG or JPEG format, allow it to be an ImageData object with raw pixel data. This is useful if, for example, you are looking for a QR code in a portion of an image you've already loaded and cropped.